### PR TITLE
Augury [Intro] Page — improve grammar, phrasing, and fix spelling mistakes

### DIFF
--- a/guide/augury/augury.md
+++ b/guide/augury/augury.md
@@ -1,10 +1,10 @@
 # Welcome to Augury
 
-In this section you will learn what Augury is, and get introduced to the features that are available. Later lessons in this guide will go into more details, each lesson will explain Augury using a demo Angular application.
+In this section you will learn about what Augury is and the features that are available. Later lessons in this guide will go into more detail, with each lesson that will have an accompanying demo Angular application.
 
-Augury is a Angular application inspection tools that runs in the Web browser. Augury runs as a Developer Tools (DevTools) browser _extension_, aiding in the analysis and debugging phases of development.
+Augury is an application inspection tool for Angular that runs in the Web browser. It runs as a Chrome browser _extension_ for the Developer Tools (DevTools) panel, aiding in analysis and debugging during development.
 
-Augury provides better insight to an Angular application structure and the relationship between these building blocks:
+The tool provides insight into the application structure for an Angular application and the relationships between these building blocks:
 
 * Components
 * Services
@@ -16,15 +16,15 @@ Augury provides better insight to an Angular application structure and the relat
 * Events
 * Object properties
 
-Augury compliments DevTools during a debugging session, making it easy to modify states and emit events.
+Augury compliments DevTools during a debugging session, making it easy to modify state and emit events.
 
 ## Installing Augury
 
-The best way to install Augury is to head over to [chrome web store](https://chrome.google.com/webstore/category/extensions?hl=en). Once there, select _Extensions_ from the side panel and type "Augury" into the search field, then press _Enter_.
+The best way to install Augury is from the [chrome web store](https://chrome.google.com/webstore/category/extensions?hl=en). Select _Extensions_ from the side panel, type "Augury" into the search field, and then press <kbd>Enter</kbd>.
 
 ![Image Chrome Web store](images/chrome-web-store.png)
 
-The Augury extension similar to the following from _rangle.io_ should be visible.
+The search result should list the Augury extension by _Rangle.io_:
 
 ![Image Augury extension](images/augury-extension.png)
 
@@ -32,55 +32,58 @@ When you click on "Add To Chrome", a _popup_ will open. Select "Add extension" t
 
 ![Image Extension logo](images/extension-logo.png)
 
-The Augury icon provides additional information. Click on the icon now to discover what that is.
+The Augury icon provides additional information. Click on the icon now to see what is available.
 
 ## Using Augury
 
-To start using Augury, you must have an Angular application running in the browser for inspection. If you have never debugged a JavaScript application, you may not be aware that each modern Web browser provides a debug environment straight in the browser. _DevTools_, the debug environment is opened using the following _shortcut_:
+To start using Augury, you must have an Angular application running in the browser. If you have never debugged a JavaScript application before, you may not be aware of the debugging environment that most modern browsers provide.
 
-* On Linux use `Ctrl + Shift + I`
-* On Mac use `Cmd + Opt + I on Mac`
-* On Windows use `Ctrl + Shift + I`
+_DevTools_, the debug environment, is opened using the following _shortcut_:
+
+* For Windows and Linux, use <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd>
+* For Mac OS X, use <kbd>Cmd</kbd> + <kbd>Opt</kbd> + <kbd>I</kbd>
 
 When DevTools is opened, you will find the Augury tab on the far right.
 
 ![Image DevTools](images/devtools.png)
 
-## Augury features
+## Augury Features
 
-We will walk quickly through the main functionality that is available in Augury. This is to become familiar with the features and how to locate them when needed.
+We will quickly go through the main functionality available in Augury. This will allow you to become familiar with the features so you can locate them when needed.
 
 The first view that is visible is the _Component Tree_ which shows **loaded** components belonging to the application.
 
 ![Image Component tree](images/component-tree.png)
 
-The component tree shows the hierarchal relationship of the _components_. When a _component_ is selected, Augury presents additional information about the _component_ in the _Properties_ tab.
+The component tree displays a hierarchical relationship of the _components_. When a _component_ is selected, Augury presents additional information about the selected _component_ in the _Properties_ tab.
 
+<!-- instead of using HTML here, the global
+  CSS should use `max-width: 100%` for all img tags -->
 <img src="images/properties.png" style="width: 100%">
 
 Notable items of interest are:
 
-1. View source link
-1. Change Detection in use
-1. Object properties
-1. Dependencies
+1. **View Source** — a link to the source code of the component.
+1. **Change Detection** — displays whether or not Change Detection is in use for the component.
+1. **Object Properties** — lists the properties of the component.
+1. **Dependencies** - lists the dependencies of the component.
 
 To view the source code of the selected _component_, click the 'View Source' link. This will bring the _Sources_ tab into focus and display the source code.
 
-### Source map
+### Source Map
 
-One thing to keep in mind, the _TypeScript_ code will only be shown if a _source map_ from the build exists. In production if no _source map_ is available, what you will see is the compiled JavaScript code, which may also be minified and difficult to read.
+One thing to keep in mind is that the _TypeScript_ code will only be shown if a _source map_ file exists. In production, if no _source map_ is found, what you will see instead is the compiled JavaScript code, which may also be minified and difficult to read.
 
-Next to the _Properties_ tab is the _Injector Graph_, clicking on it will display the dependency of _components_ and _services_.
+Next to the _Properties_ tab is the _Injector Graph_, clicking on it will display the dependency relationships of _components_ and _services_.
 
 ![Image Injector graph](images/injector-graph.png)
 
-We will learn more on how to interpret the _ dependency graph_in later lessons.
+We will learn more about how to interpret the _Injector Graph_ in later lessons.
 
-The last major feature of Augury is the _Router Tree_ which displays the routing information for the application. The _Router Tree_ tab is located next to the _Component Tree_ tab along the top left side.
+The final major feature of Augury is the _Router Tree_, which displays the routing information for the application. The _Router Tree_ tab is located next to the _Component Tree_ tab along the top left side.
 
 ![Image Router tree](images/router-tree.png)
 
-There are a few things we didn't cover here such as data binding and events which will be covered in other lessons. However you now have a good basic understand of Augury and how to start exploring it as well as all an Angular application.
+There are a few things we didn't cover here such as data binding and events which will be covered in other lessons. However, you now have a basic understanding of Augury and how to start exploring its features with an Angular application.
 
-Augury has evolved and improved over time since its debut, and it will continue to improve. We hope you come to love Augury and make it an indispensable tool in your toolbox. We love and welcome feedbacks, come join us on Slack [Angular Augury](https://augury-slack.herokuapp.com).
+Augury has evolved and improved over time since its debut, and it will continue to improve. We hope you will come to love Augury and make it an indispensable tool in your toolbox. We love and welcome all feedback, come join us on our [Slack channel](https://augury-slack.herokuapp.com).

--- a/guide/augury/augury.md
+++ b/guide/augury/augury.md
@@ -20,7 +20,7 @@ Augury compliments DevTools during a debugging session, making it easy to modify
 
 ## Installing Augury
 
-The best way to install Augury is from the [chrome web store](https://chrome.google.com/webstore/category/extensions?hl=en). Select _Extensions_ from the side panel, type "Augury" into the search field, and then press `Enter`.
+The best way to install Augury is from the [chrome web store](https://chrome.google.com/webstore/category/extensions?hl=en). Select _Extensions_ from the side panel, type "Augury" into the search field, and then press _Enter_.
 
 ![Image Chrome Web store](images/chrome-web-store.png)
 
@@ -47,7 +47,7 @@ When DevTools is opened, you will find the Augury tab on the far right.
 
 ## Augury features
 
-We will walk quickly through the main functionality that is available in Augury. This is to become familiar with the features and how to locate them when needed.
+We will quickly go over the main functionality that is available in Augury. This is to become familiar with the features and how to locate them when needed.
 
 The first view that is visible is the _Component Tree_ which shows **loaded** components belonging to the application.
 

--- a/guide/augury/augury.md
+++ b/guide/augury/augury.md
@@ -4,7 +4,7 @@ In this section you will learn about what Augury is and the features that are av
 
 Augury is an application inspection tool for Angular that runs in the Web browser. It runs as a Chrome browser _extension_ for the Developer Tools (DevTools) panel, aiding in analysis and debugging during development.
 
-The tool provides insight into the application structure for an Angular application and the relationships between these building blocks:
+Augury provides insight into the application structure for an Angular application and the relationship between these building blocks:
 
 * Components
 * Services
@@ -20,7 +20,7 @@ Augury compliments DevTools during a debugging session, making it easy to modify
 
 ## Installing Augury
 
-The best way to install Augury is from the [chrome web store](https://chrome.google.com/webstore/category/extensions?hl=en). Select _Extensions_ from the side panel, type "Augury" into the search field, and then press <kbd>Enter</kbd>.
+The best way to install Augury is from the [chrome web store](https://chrome.google.com/webstore/category/extensions?hl=en). Select _Extensions_ from the side panel, type "Augury" into the search field, and then press `Enter`.
 
 ![Image Chrome Web store](images/chrome-web-store.png)
 
@@ -32,24 +32,22 @@ When you click on "Add To Chrome", a _popup_ will open. Select "Add extension" t
 
 ![Image Extension logo](images/extension-logo.png)
 
-The Augury icon provides additional information. Click on the icon now to see what is available.
+The Augury icon provides additional information. Click on the icon now to discover what that is.
 
 ## Using Augury
 
-To start using Augury, you must have an Angular application running in the browser. If you have never debugged a JavaScript application before, you may not be aware of the debugging environment that most modern browsers provide.
+To start using Augury, you must have an Angular application running in the browser for inspection. If you have never debugged a JavaScript application, you may not be aware that each modern Web browser provides a debug environment straight in the browser. _DevTools_, the debug environment is opened using the following _shortcut_:
 
-_DevTools_, the debug environment, is opened using the following _shortcut_:
-
-* For Windows and Linux, use <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>I</kbd>
-* For Mac OS X, use <kbd>Cmd</kbd> + <kbd>Opt</kbd> + <kbd>I</kbd>
+* For Windows and Linux, use `Ctrl + Shift + I`
+* For Mac OS X, use `Cmd + Opt + I`
 
 When DevTools is opened, you will find the Augury tab on the far right.
 
 ![Image DevTools](images/devtools.png)
 
-## Augury Features
+## Augury features
 
-We will quickly go through the main functionality available in Augury. This will allow you to become familiar with the features so you can locate them when needed.
+We will walk quickly through the main functionality that is available in Augury. This is to become familiar with the features and how to locate them when needed.
 
 The first view that is visible is the _Component Tree_ which shows **loaded** components belonging to the application.
 
@@ -57,24 +55,22 @@ The first view that is visible is the _Component Tree_ which shows **loaded** co
 
 The component tree displays a hierarchical relationship of the _components_. When a _component_ is selected, Augury presents additional information about the selected _component_ in the _Properties_ tab.
 
-<!-- instead of using HTML here, the global
-  CSS should use `max-width: 100%` for all img tags -->
 <img src="images/properties.png" style="width: 100%">
 
 Notable items of interest are:
 
-1. **View Source** — a link to the source code of the component.
-1. **Change Detection** — displays whether or not Change Detection is in use for the component.
-1. **Object Properties** — lists the properties of the component.
-1. **Dependencies** - lists the dependencies of the component.
+1. View Source — a link to the source code of the component.
+1. Change Detection — displays whether or not Change Detection is in use for the component.
+1. Object Properties — lists the properties of the component.
+1. Dependencies - lists the dependencies of the component.
 
 To view the source code of the selected _component_, click the 'View Source' link. This will bring the _Sources_ tab into focus and display the source code.
 
-### Source Map
+### Source map
 
-One thing to keep in mind is that the _TypeScript_ code will only be shown if a _source map_ file exists. In production, if no _source map_ is found, what you will see instead is the compiled JavaScript code, which may also be minified and difficult to read.
+One thing to keep in mind, the _TypeScript_ code will only be shown if a _source map_ file exists. In production, if no _source map_ is found, what you will see is the compiled JavaScript code, which may also be minified and difficult to read.
 
-Next to the _Properties_ tab is the _Injector Graph_, clicking on it will display the dependency relationships of _components_ and _services_.
+Next to the _Properties_ tab is the _Injector Graph_, clicking on it will display the dependency of _components_ and _services_.
 
 ![Image Injector graph](images/injector-graph.png)
 


### PR DESCRIPTION
I have gone through the Augury [intro] page and have made a bunch of changes to:

* Spelling;
* Grammar, and;
* Phrasing for ease of understanding.

Note that I have also changed all references to keyboard keys so that they use the native `<kbd>` tag for better styling flexibility and to be in compliance with documentation best practices.

Example: <kbd>ctrl</kbd> instead of `ctrl`.