### PR TITLE
Modules Page — fix grammar, spelling, and image style

### DIFF
--- a/guide/module-list/module-list.md
+++ b/guide/module-list/module-list.md
@@ -1,16 +1,16 @@
 <img src="images/app-module-demo.png" style="width: 90%" alt="App Module Demo" />
 
-[Launch Demo Application](https://augury.angular.io/examples/modules/app)
+<a href="https://augury.angular.io/examples/modules/app" target="_blank">Launch Demo Application</a>
 
 ## Description
 
-We will use a simple Angular application, _Song List_ to examine how to use Augury's module list feature. The application includes a simple form for the user to search for songs and will use the public spotify API to get the results and display the album art and song title in a list.
+We will use a simple Angular application, _Song List_ to examine how to use Augury's module list feature. The application includes a simple form for the user to search for songs and will use the public Spotify API to get the results and display the album art and song title in a list.
 
 ## Architecture
 
-The _Song List_ application is composed of two modules. One, the root application module which is used to bootstrap and launch the application. The second is a single feature module that contains the components, services and pipes relevant for the searching and displaying of song data. Lets take a look at how this is organized:
+The _Song List_ application is composed of two modules. One, the root application module which is used to bootstrap and launch the application. The second is a single feature module that contains the components, services, and pipes relevant for the searching and displaying of song data. Lets take a look at how this is organized:
 
-<img src="images/module-breakdown.png" style="width: 90%" alt="Module Breakdown" />
+<img src="images/module-breakdown.png" style="width: 480px; max-width: 90%;" alt="Module Breakdown" />
 
 The Songs Module is a _feature_ module, which exports a component, `SongsComponent` that can be used throughtout the application. This is used in the `AppComponent`, which is our _root_ component that will bootstrap the application.
 
@@ -26,13 +26,13 @@ To use Augury, lets open up DevTools with the following shortcut:
 Ctrl + Shift + I (Cmd + Opt + I on Mac)
 ```
 
-When the DevTools panel opens, select the **Augury** tab located on the far right. By default the _Component Tree_ tab will be open. To the far right, there will be a tab labelled _NgModules_. This is the section we want so click on it to open it up!
+When the DevTools panel opens, select the **Augury** tab located on the far right. By default the _Component Tree_ tab will be open. To the far right, there will be a tab labeled _NgModules_. This is the section we want so click on it to open it up!
 
 ## Root Module
 
 <img src="images/module-list-1.png" style="width: 90%" alt="Module List AppModule" />
 
-The _Module List_ feature lists all the modules in the application. The first module in this list is the `AppModule`. Here we can see what _imports_, _exports_, _providers_, _declarations_, and _providers in declarations_ are found in the module. Our `AppModule` imports the `BrowserModule` (used for bootstrapping), `HttpModule` (used for performin network requests) and our feature module, `SongsModule`. Since the `AppModule` contains the applications root component it doesn't need to export anything. The `AppModule` has a single Provider, `LoggerService` which is a simple service used for logging messages. Finally, the `AppModule` has one component, `AppComponent` which is the root component of our application and as such is the bootstrap entry point.
+The _Module List_ feature lists all the modules in the application. The first module in this list is the `AppModule`. Here we can see what _imports_, _exports_, _providers_, _declarations_, and _providers in declarations_ are found in the module. Our `AppModule` imports the `BrowserModule` (used for bootstrapping), `HttpModule` (used for performing network requests) and our feature module, `SongsModule`. Since the `AppModule` contains the application's root component it doesn't need to export anything. The `AppModule` has a single Provider, `LoggerService` which is a simple service used for logging messages. Finally, the `AppModule` has one component, `AppComponent` which is the root component of our application and as such is the bootstrap entry point.
 
 To see where Augury gets this information from, open up `app.module.ts` and take a look at the `AppModule` source code:
 
@@ -64,11 +64,11 @@ export class AppModule { }
 
 As you can see, the information that Augury has picked out and displayed in the _Module List_ comes directly from the `NgModule` definition.
 
-Declarations include the components, directive and pipes used by the module.
+Declarations include the components, directives, and pipes used by the module.
 
 Imports are the other modules and their exported declarations that we want to be made available in this module.
 
-Providers list the services used by this module. Any service included as a provider in the `NgModel` definition becomes available to any other module in the hierarchical dependency injection system. For example, the `SongsModule` includeds the `SongService` as a provider, since `AppModule` has imported the `SongsModule` it can now use the `SongService`. If we omitted the `SongService `from the `NgModel` definition of the `SongsModel` and instead opted to include the `SongService` in the provider definition of the `SongsComponent`, the `AppModule` will not have access to the `SongService`. Dependency Injection is a topic outside the scope of this guide, but you can read more about it on the [Angular 2 Documentation](https://angular.io/docs/ts/latest/guide/hierarchical-dependency-injection.html)
+Providers list the services used by this module. Any service included as a provider in the `NgModel` definition becomes available to any other module in the hierarchical dependency injection system. For example, the `SongsModule` includes the `SongService` as a provider, since `AppModule` has imported the `SongsModule` it can now use the `SongService`. If we omitted the `SongService` from the `NgModel` definition of the `SongsModel` and instead opted to include the `SongService` in the provider definition of the `SongsComponent`, the `AppModule` will not have access to the `SongService`. Dependency Injection is a topic outside the scope of this guide, but you can read more about it on the [Angular 2 Documentation](https://angular.io/docs/ts/latest/guide/hierarchical-dependency-injection.html)
 
 So now that we've taken a look at the root module of our application, let us continue on to the other modules in Augury's module list.
 
@@ -92,7 +92,7 @@ Feature modules can be thought of as extending the functionality of an applicati
 
 The `SongsModule` also uses the `SongService` as seen under the provider section.
 
-Lets take a look at the definition of the Song Module, open up `src/app/modules/songs.module.ts`:
+Let's take a look at the definition of the Song Module, open up `src/app/modules/songs.module.ts`:
 
 ```js
 import {NgModule} from '@angular/core';
@@ -128,7 +128,7 @@ export class SongsModule {}
 
 Just like our root module, Augury has picked out the `imports`, `declarations`, `providers` and `exports` information from our module definition.
 
-One important thing to take note of is that _Module List_ does not include any resources (pipes, providers, directives, components, etc) that a module may use, just the resources definied by `NgModule`. For example, open up the `SongListComponent` (`components/song-list/song-list.component.ts`), here is what it should look like:
+One important thing to take note of is that _Module List_ does not include any resources (pipes, providers, directives, components, etc) that a module may use, just the resources defined by `NgModule`. For example, open up the `SongListComponent` (`components/song-list/song-list.component.ts`), here is what it should look like:
 
 ```js
 export class SongListComponent {
@@ -145,9 +145,9 @@ export class SongListComponent {
 }
 ```
 
-The `SongListComponent` uses the `Logger` service via dependency injection that has been made available from the `AppModule`. Since the `AppModule` is at the root of the applications dependency injection hierarchy, the `SongListComponent` can use any of its providers. However, since the `Logger service` is defined in the `AppModule`, Augury will list this service under the providers section of the `AppModule`. It is not included in the section of the `SongsModule`, even though the `SongsModule` uses this service. To get a better sense of dependency injection throughout our application we should use Augury's Dependency Injection Tree.
+The `SongListComponent` uses the `Logger` service via dependency injection that has been made available from the `AppModule`. Since the `AppModule` is at the root of the application's dependency injection hierarchy, the `SongListComponent` can use any of its providers. However, since the `Logger service` is defined in the `AppModule`, Augury will list this service under the providers section of the `AppModule`. It is not included in the section of the `SongsModule`, even though the `SongsModule` uses this service. To get a better sense of dependency injection throughout our application we should use Augury's Dependency Injection Tree.
 
-Lets see what happens when we remove the `SongService` from the provider list in the `SongModule` definition and move it to the provider list in the `SongsComponent` component definition. Here is what `SongsComponent` will look like:
+Let's see what happens when we remove the `SongService` from the provider list in the `SongModule` definition and move it to the provider list in the `SongsComponent` component definition. Here is what `SongsComponent` will look like:
 
 ```js
 @Component({
@@ -172,7 +172,7 @@ Lets see what happens when we remove the `SongService` from the provider list in
 export class SongsComponent { ...
 ```
 
-Augury has picked up what we've done and has noticed that the `SongService` is not longer a provider from the module level, but instead from the component level. As we can see below, `SongService` is now under the _ProvidersInDeclarations_ section.
+Augury has picked up on what we've done and has noticed that the `SongService` is no longer a provider from the module level, but instead from the component level. As we can see below, `SongService` is now under the _ProvidersInDeclarations_ section.
 
 <img src="images/module-list-4.png" style="width: 90%" alt="Module List 4" />
 

--- a/guide/module-list/module-list.md
+++ b/guide/module-list/module-list.md
@@ -26,7 +26,7 @@ To use Augury, lets open up DevTools with the following shortcut:
 Ctrl + Shift + I (Cmd + Opt + I on Mac)
 ```
 
-When the DevTools panel opens, select the **Augury** tab located on the far right. By default the _Component Tree_ tab will be open. To the far right, there will be a tab labeled _NgModules_. This is the section we want so click on it to open it up!
+When the DevTools panel opens, select the Augury tab located on the far right. By default the _Component Tree_ tab will be open. To the far right, there will be a tab labeled _NgModules_. This is the section we want so click on it to open it up!
 
 ## Root Module
 
@@ -92,7 +92,7 @@ Feature modules can be thought of as extending the functionality of an applicati
 
 The `SongsModule` also uses the `SongService` as seen under the provider section.
 
-Let's take a look at the definition of the Song Module, open up `src/app/modules/songs.module.ts`:
+Let us take a look at the definition of the Song Module, open up `src/app/modules/songs.module.ts`:
 
 ```js
 import {NgModule} from '@angular/core';
@@ -147,7 +147,7 @@ export class SongListComponent {
 
 The `SongListComponent` uses the `Logger` service via dependency injection that has been made available from the `AppModule`. Since the `AppModule` is at the root of the application's dependency injection hierarchy, the `SongListComponent` can use any of its providers. However, since the `Logger service` is defined in the `AppModule`, Augury will list this service under the providers section of the `AppModule`. It is not included in the section of the `SongsModule`, even though the `SongsModule` uses this service. To get a better sense of dependency injection throughout our application we should use Augury's Dependency Injection Tree.
 
-Let's see what happens when we remove the `SongService` from the provider list in the `SongModule` definition and move it to the provider list in the `SongsComponent` component definition. Here is what `SongsComponent` will look like:
+Let us see what happens when we remove the `SongService` from the provider list in the `SongModule` definition and move it to the provider list in the `SongsComponent` component definition. Here is what `SongsComponent` will look like:
 
 ```js
 @Component({
@@ -172,7 +172,7 @@ Let's see what happens when we remove the `SongService` from the provider list i
 export class SongsComponent { ...
 ```
 
-Augury has picked up on what we've done and has noticed that the `SongService` is no longer a provider from the module level, but instead from the component level. As we can see below, `SongService` is now under the _ProvidersInDeclarations_ section.
+Augury has picked up what we've done and has noticed that the `SongService` is no longer a provider from the module level, but instead from the component level. As we can see below, `SongService` is now under the _ProvidersInDeclarations_ section.
 
 <img src="images/module-list-4.png" style="width: 90%" alt="Module List 4" />
 


### PR DESCRIPTION
* Fixed spelling and punctuation mistakes.
* Made the link for the demo open in a new tab.
* Added `max-width` setting to image under the Architecture section to prevent it from becoming too large.