### PR TITLE
updating links to match new hash structure of examples repo

### DIFF
--- a/guide/dependency-injection/dependency-injection.md
+++ b/guide/dependency-injection/dependency-injection.md
@@ -1,6 +1,6 @@
 ![Image Empty Form](images/form-empty.png)
 
-<a href="/examples/dependency-injection" target="blank">Launch Demo Application</a>
+<a href="/examples/#/dependency-injection" target="blank">Launch Demo Application</a>
 
 ## Description
 

--- a/guide/input-output-app/io-app.md
+++ b/guide/input-output-app/io-app.md
@@ -1,6 +1,6 @@
 <img src="images/io-app.png" style="width: 100%">
 
-<a href="/examples/input-output" target="blank">Launch Demo Application</a>
+<a href="/examples/#/input-output" target="blank">Launch Demo Application</a>
 
 ## Description
 

--- a/guide/module-list/module-list.md
+++ b/guide/module-list/module-list.md
@@ -1,6 +1,6 @@
 <img src="images/app-module-demo.png" style="width: 90%" alt="App Module Demo" />
 
-<a href="/examples/modules" target="_blank">Launch Demo Application</a>
+<a href="/examples/#/modules" target="_blank">Launch Demo Application</a>
 
 ## Description
 

--- a/guide/routes/routes.md
+++ b/guide/routes/routes.md
@@ -1,6 +1,6 @@
 ![Image NYC Metro](images/routes-nyc.png)
 
-<a href="/examples/routes" target="blank">Launch Demo Application</a>
+<a href="/examples/#/routes" target="blank">Launch Demo Application</a>
 
 ## Description
 

--- a/l10n/cn/dependency-injection/dependency-injection.md
+++ b/l10n/cn/dependency-injection/dependency-injection.md
@@ -1,6 +1,6 @@
 ![Image Empty Form](images/form-empty.png)
 
-<a href="/examples/dependency-injection" target="blank">Launch Demo Application</a>
+<a href="/examples/#/dependency-injection" target="blank">Launch Demo Application</a>
 
 ## Description
 

--- a/l10n/cn/input-output-app/io-app.md
+++ b/l10n/cn/input-output-app/io-app.md
@@ -1,6 +1,6 @@
 <img src="images/io-app.png" style="width: 100%">
 
-<a href="/examples/input-output" target="blank">Launch Demo Application</a>
+<a href="/examples/#/input-output" target="blank">Launch Demo Application</a>
 
 ## Description
 

--- a/l10n/cn/module-list/module-list.md
+++ b/l10n/cn/module-list/module-list.md
@@ -1,6 +1,6 @@
 <img src="images/app-module-demo.png" style="width: 90%" alt="App Module Demo" />
 
-<a href="/examples/modules" target="_blank">Launch Demo Application</a>
+<a href="/examples/#/modules" target="_blank">Launch Demo Application</a>
 
 ## Description
 

--- a/l10n/cn/routes/routes.md
+++ b/l10n/cn/routes/routes.md
@@ -1,6 +1,6 @@
 ![Image NYC Metro](images/routes-nyc.png)
 
-<a href="/examples/routes" target="blank">Launch Demo Application</a>
+<a href="/examples/#/routes" target="blank">Launch Demo Application</a>
 
 ## Description
 


### PR DESCRIPTION
updating links to match new hash structure of examples repo.
closes #89 